### PR TITLE
Implement Upload Page UI with image picker and empty state

### DIFF
--- a/Application/app/src/main/java/com/example/wallgodds/screens/UploadPage.kt
+++ b/Application/app/src/main/java/com/example/wallgodds/screens/UploadPage.kt
@@ -1,25 +1,139 @@
 package com.example.wallgodds.screens
 
-
+import android.net.Uri
+import androidx.activity.compose.rememberLauncherForActivityResult
+import androidx.activity.result.contract.ActivityResultContracts
+import androidx.compose.foundation.Image
+import androidx.compose.foundation.background
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material3.Icon
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.runtime.getValue
+import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.res.painterResource
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
 import androidx.navigation.NavController
+import com.example.wallgodds.R
 import com.example.wallgodds.ui.theme.AppPadding
-import com.example.wallgodds.utils.ContentPlaceholder
+import com.example.wallgodds.ui.theme.poppinsFontFamily
+import com.example.wallgodds.utils.dashedBorder
 
 @Composable
 fun UploadPage(navController: NavController) {
+
+    var selectedImageUri by remember { mutableStateOf<Uri?>(null) }
+    val launcher = rememberLauncherForActivityResult(
+        contract = ActivityResultContracts.GetContent()
+    ) { uri: Uri? ->
+        selectedImageUri = uri
+    }
+
     Column(
         modifier = Modifier
             .fillMaxSize()
             .padding(horizontal = AppPadding.MainContentPadding)
+            .padding(bottom = 90.dp),
+        horizontalAlignment = Alignment.CenterHorizontally,
     ) {
-        // Code here
-        ContentPlaceholder()
-    }
 
+        Spacer(modifier = Modifier.height(24.dp))
+
+        Box(
+            modifier = Modifier
+                .fillMaxWidth()
+                .height(260.dp)
+                .clip(RoundedCornerShape(46.dp))
+                .background(Color(0x85FFFFFF)) // #FFFFFF 52%
+                .dashedBorder(
+                    strokeWidth = 2.dp,
+                    color = Color(0xFF8EA3E6),
+                    cornerRadius = 46.dp,
+                    dashLength = 8.dp,
+                    gapLength = 8.dp
+                )
+                .clickable { launcher.launch("image/*") },
+            contentAlignment = Alignment.Center
+        ) {
+            Column(
+                horizontalAlignment = Alignment.CenterHorizontally
+            ) {
+                Box(
+                    modifier = Modifier
+                        .size(53.dp)
+                        .clip(RoundedCornerShape(16.dp))
+                        .background(Color(0xFFF2F5FF)),
+                    contentAlignment = Alignment.Center
+                ) {
+                    Icon(
+                        painter = painterResource(id = R.drawable.upload_icon),
+                        contentDescription = "Upload Icon",
+                        tint = Color(0xFF8EA3E6).copy(alpha = 0.75f),
+                        modifier = Modifier.size(45.dp)
+                    )
+                }
+
+                Spacer(modifier = Modifier.height(12.dp))
+
+                Text(
+                    text = "Upload an Image",
+                    fontSize = 16.sp,
+                    fontWeight = FontWeight.Normal,
+                    fontFamily = poppinsFontFamily,
+                    color = Color(0xFF3C56B1)
+                )
+            }
+        }
+
+        Spacer(modifier = Modifier.height(180.dp))
+
+        Column(
+            horizontalAlignment = Alignment.CenterHorizontally
+        ) {
+
+            Text(
+                text = "Nothing here yet.",
+                fontSize = 18.sp,
+                fontWeight = FontWeight.Medium,
+                fontFamily = poppinsFontFamily,
+                color = Color(0xFF808080)
+            )
+
+            Spacer(modifier = Modifier.height(6.dp))
+
+            Text(
+                text = "Upload a wallpaper to share your creativity.",
+                fontSize = 14.sp,
+                fontWeight = FontWeight.Normal,
+                fontFamily = poppinsFontFamily,
+                color = Color(0xFF808080),
+                textAlign = TextAlign.Center
+            )
+        }
+
+        Spacer(modifier = Modifier.height(40.dp))
+    }
 }
+
+
 

--- a/Application/app/src/main/java/com/example/wallgodds/ui/theme/Type.kt
+++ b/Application/app/src/main/java/com/example/wallgodds/ui/theme/Type.kt
@@ -39,3 +39,8 @@ val guedFontFamily = FontFamily(
     Font(R.font.gued, FontWeight.Normal),
     Font(R.font.gued_bold, FontWeight.Bold),
 )
+
+val poppinsFontFamily = FontFamily(
+    Font(R.font.poppins_regular, FontWeight.Normal),
+    Font(R.font.poppins_medium, FontWeight.Medium)
+)


### PR DESCRIPTION
# Description  

- Implemented the revamped Upload Page UI for the WallGodds app as per the provided Figma design.
- This includes the upload card with dashed border, upload icon section, and the empty state UI.
- Also added an image picker using ActivityResultContracts.GetContent() to allow users to select an image from device storage and store its URI in a variable (no backend/upload functionality included as per issue requirements).

---

## Type of Change  
<!-- Check the box that best describes your change. -->  
- [ ] 🆕 New Feature  
- [ ] 🐛 Bug Fix  
- [ ] 🖼 Wallpaper Added 
- [X] 🎨 UI/Design Update  
- [ ] 🔄 Refactor/Code Improvement  
- [ ] 📂 Other (Specify here):  

**Issue Linked:**   
Fixes: UPLOAD PAGE  #64 

---

# Checklist  
- [X] 📖 I have read and followed the [Contributing Guidelines](CONTRIBUTING.md).  
- [X] ✅ My code adheres to the project's style guidelines.  
- [X] 🧪 I have tested my changes locally and ensured no existing functionality is broken.  
- [ ] ✍️ I have added or updated necessary documentation where applicable (e.g., README.md, DESIGN.md, WALLPAPER.md).  

---

# Additional Notes  
🎥 Work Demo Video: https://drive.google.com/file/d/1OXmfco3NSm4AyRSTgiDRKeHMX2CNKZrw/view?usp=sharing
